### PR TITLE
Add missing substitution rule in tutorial

### DIFF
--- a/www/docs/tutorial.md
+++ b/www/docs/tutorial.md
@@ -387,6 +387,7 @@ below):
     ! sub what're = what are
     ! sub what've = what have
     ! sub what'll = what will
+    ! sub who's   = who is
 
 Save this as `begin.rive` in your project directory. Now, for an explanation on
 what this code is doing.


### PR DESCRIPTION
The substitution rule for `who's` was missing leading to a broken experience when used in the `% Previous` section of the tutorial.
